### PR TITLE
Add a clean method to containers

### DIFF
--- a/psqtraviscontainer/container.py
+++ b/psqtraviscontainer/container.py
@@ -48,6 +48,14 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
 
     PopenArguments = namedtuple("PopenArguments", "argv env")
 
+    @staticmethod
+    def rmtree(directory):
+        """Remove directory, but ignore errors."""
+        try:
+            shutil.rmtree(directory)
+        except shutil.Error:   # suppress(useless-except)
+            pass
+
     @abc.abstractmethod
     def _subprocess_popen_arguments(self, argv):
         """Return a PopenArguments tuple.
@@ -63,6 +71,26 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
     def _package_system(self):
         """Return the package system this container should be using."""
         raise NotImplementedError()
+
+    @abc.abstractmethod
+    def clean(self):
+        """Clean this container to prepare it for caching.
+        
+        Remove any non-useful files here.
+        """
+        raise NotImplementedError()
+
+    def __enter__(self):
+        """Use this container as a context."""
+        return self
+
+    def __exit__(self, exc_type, value, traceback):
+        """Clean this container once it has been used a context."""
+        del exc_type
+        del value
+        del traceback
+
+        self.clean()
 
     def install_packages(self, repositories_path, packages_path):
         """Install packages and set up repositories as configured.

--- a/psqtraviscontainer/create.py
+++ b/psqtraviscontainer/create.py
@@ -88,13 +88,13 @@ def main(arguments=None):
     selected_distro = distro.lookup(vars(result))
 
     _print_distribution_details(selected_distro)
-    container = selected_distro["info"].create_func(container_dir,
-                                                    selected_distro)
 
     # Now set up packages in the distribution. If more packages need
     # to be installed or the installed packages need to be updated then
     # the build cache should be cleared.
-    container.install_packages(result.repositories, result.packages)
+    with selected_distro["info"].create_func(container_dir,
+                                             selected_distro) as container:
+        container.install_packages(result.repositories, result.packages)
 
     printer.unicode_safe(colored(u"""\N{check mark}  """
                                  u"""Container has been set up """

--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -121,6 +121,17 @@ class LinuxContainer(container.AbstractContainer):
         """Return package system for this distribution."""
         return self._pkgsys
 
+    def clean(self):
+        """Clean out this container."""
+        container.AbstractContainer.rmtree(os.path.join(self._distro_dir,
+                                                        "tmp"))
+        container.AbstractContainer.rmtree(os.path.join(self._distro_dir,
+                                                        "var",
+                                                        "cache",
+                                                        "apt",
+                                                        "archives"))
+        container.AbstractContainer.rmtree(os.path.join(self._distro_dir,
+                                                        "dev"))
 
 def _extract_deb_data(archive, tmp_dir):
     """Extract archive to tmp_dir."""

--- a/psqtraviscontainer/osx_container.py
+++ b/psqtraviscontainer/osx_container.py
@@ -67,6 +67,9 @@ class OSXContainer(container.AbstractContainer):
         """Return package system for this distribution."""
         return self._pkgsys
 
+    def clean(self):
+        """Clean out this container to prepare it for caching."""
+        pass
 
 def _extract_archive(archive_file, container_folder):
     """Extract distribution archive into container_folder."""

--- a/psqtraviscontainer/use.py
+++ b/psqtraviscontainer/use.py
@@ -40,10 +40,9 @@ def main(arguments=None):
 
     container_dir = os.path.realpath(argparse_result.containerdir)
     selected_distro = distro.lookup(vars(argparse_result))
-    container = selected_distro["info"].get_func(container_dir,
-                                                 selected_distro)
-
-    result, stdout, stderr = container.execute(command)
+    with selected_distro["info"].get_func(container_dir,
+                                          selected_distro) as container:
+        result, stdout, stderr = container.execute(command)
 
     if argparse_result.show_output:
         sys.stdout.write(stdout)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import find_packages, setup
 
 setup(name="psqtraviscontainer",
-      version="0.0.3",
+      version="0.0.4",
       description="Polysquare Travis-CI Container Root",
       long_description_markdown_filename="README.md",
       author="Sam Spilsbury",


### PR DESCRIPTION
Use this to clean out noncopyable files, or files that shouldn't
be cached, like internal caches that will never be used again.