### PR TITLE
Delete /var/run on linux container cleanup

### DIFF
--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -157,6 +157,7 @@ class LinuxContainer(container.AbstractContainer):
 
         rmtree(os.path.join(self._distro_dir, "tmp"))
         rmtree(os.path.join(self._distro_dir, "var", "cache", "apt"))
+        rmtree(os.path.join(self._distro_dir, "var", "run"))
         rmtree(os.path.join(self._distro_dir, "usr", "share", "doc"))
         rmtree(os.path.join(self._distro_dir, "usr", "share", "locale"))
         rmtree(os.path.join(self._distro_dir, "usr", "share", "man"))


### PR DESCRIPTION
This is mounted on tmpfs anyway and can be safely removed.