### PR TITLE
Parse shebang before passing command to subprocess

### DIFF
--- a/DICTIONARY
+++ b/DICTIONARY
@@ -21,6 +21,7 @@ Executables
 executables
 Fedora
 filename
+filename's
 filesystem
 flake8
 getter
@@ -29,6 +30,7 @@ homebrew
 launchpad
 OSX
 overridable
+PATHEXT
 PermissionError
 _POLYSQUARE_TRAVIS_CONTAINER_TEST_CACHE_DIR
 PPA

--- a/psqtraviscontainer/container.py
+++ b/psqtraviscontainer/container.py
@@ -44,6 +44,28 @@ def updated_environ(prepend):
         os.environ = old_environ
 
 
+def _shebang_parts(executable):
+    """Return any shebang from executable to be prepended to invocation.
+
+    If the filename's extension is in PATHEXT, then don't read the shebang,
+    as Windows will know how to handle it for us.
+    """
+    pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+    if os.path.splitext(executable)[1] in pathext:
+        return []
+
+    with open(executable, "r") as fileobj:
+        try:
+            part = fileobj.read(2)
+        except UnicodeDecodeError:
+            part = ""
+
+        if part == "#!":
+            return fileobj.readline().strip().split(" ")
+
+    return []
+
+
 class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
 
     """An abstract class representing an OS container."""
@@ -133,9 +155,9 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
 
         with updated_environ(modify_env) as env:
             argv[0] = shutil.which(argv[0])
-
             assert argv[0] is not None
 
+            argv = _shebang_parts(argv[0]) + argv
             executed_cmd = subprocess.Popen(argv,
                                             stdout=stdout,
                                             stderr=stderr,


### PR DESCRIPTION
This allow direct execution of scripts on platforms like
Windows, where shebang parsing isn't usually supported