### PR TITLE
Disable jobstamps on Travis-CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ before_deploy:
 - polysquare_run deploy/python/deploy.py
 env:
   global:
-    secure: Qw1ZpPGW305MqXUGhj1luETKKluW0KXX/ZZ+q5ZSsh/0TdIi5Oqm85UblyEF0zm6LIGI6TStZ4z5Mg3ZbGcH4gK+CItAt8HTGBU6MAhFfj+Kvo4uznJgzb1ntH7NhrPW+H6hBY5Vy0qivojSKwoy6nbIMXLY7UIxO6n/OxT8R8Y=
+    - JOBSTAMPS_DISABLED=1
+    - secure: Qw1ZpPGW305MqXUGhj1luETKKluW0KXX/ZZ+q5ZSsh/0TdIi5Oqm85UblyEF0zm6LIGI6TStZ4z5Mg3ZbGcH4gK+CItAt8HTGBU6MAhFfj+Kvo4uznJgzb1ntH7NhrPW+H6hBY5Vy0qivojSKwoy6nbIMXLY7UIxO6n/OxT8R8Y=
 deploy:
   provider: pypi
   user:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(name="polysquare-travis-container",
               "tempdir"
           ],
           "polysquarelint": [
-              "polysquare-setuptools-lint>=0.0.21"
+              "polysquare-setuptools-lint>=0.0.25"
           ],
           "upload": [
               "setuptools-markdown"


### PR DESCRIPTION
jobstamps inevitably cause caches to be re-uploaded, which
is a hugely expensive operation on this repository, far
outweighing the expensive of just running those jobs again.