### PR TITLE
linux_local_container: Extract debs directly, don't use dpkg

### DIFF
--- a/psqtraviscontainer/debian.py
+++ b/psqtraviscontainer/debian.py
@@ -1,0 +1,21 @@
+# /psqtraviscontainer/debian.py
+#
+# Functionality common to debian packages.
+#
+# See /LICENCE.md for Copyright information
+"""Functionality common to debian packages."""
+
+import tarfile
+
+from contextlib import closing
+
+
+def extract_deb_data(archive, extract_dir):
+    """Extract archive to extract_dir."""
+    # We may not have python-debian installed on all platforms
+    from debian import arfile  # suppress(import-error)
+
+    with closing(arfile.ArFile(archive).getmember("data.tar.gz")) as member:
+        with tarfile.open(fileobj=member,
+                          mode="r|*") as data_tar:
+            data_tar.extractall(path=extract_dir)

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -37,24 +37,6 @@ def get_dir_for_distro(container_dir, config):
     return os.path.realpath(os.path.join(container_dir, distro_folder_name))
 
 
-def force_make_dirs(directories):
-    """Make directories."""
-    for directory_name in directories:
-        try:
-            os.makedirs(directory_name)
-        except OSError as error:
-            if error.errno != errno.EEXIST:
-                raise error
-
-
-def force_make_files(files):
-    """Make files."""
-    for filename in files:
-        with open(filename, "wt") as file_instance:
-            file_instance.truncate(0)
-            file_instance.write("")
-
-
 class LocalLinuxContainer(container.AbstractContainer):
     """A container for a linux distribution.
 
@@ -73,22 +55,6 @@ class LocalLinuxContainer(container.AbstractContainer):
         self._arch = arch
         self._package_root = package_root
         self._pkgsys = pkg_sys_constructor(release, arch, self)
-
-        directories = [
-            os.path.join(self._package_root, "var", "lib", "dpkg", "info"),
-            os.path.join(self._package_root, "var", "lib", "dpkg", "updates")
-        ]
-
-        files = [
-            os.path.join(self._package_root,
-                         "var",
-                         "lib",
-                         "dpkg",
-                         "available"),
-            os.path.join(self._package_root, "var", "lib", "dpkg", "status")
-        ]
-        force_make_dirs(directories)
-        force_make_files(files)
 
     def _root_filesystem_directory(self):
         """Return directory on parent filesystem where our root is located."""

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -11,8 +11,6 @@
 
 from __future__ import unicode_literals
 
-import errno
-
 import os
 
 import platform

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -13,16 +13,13 @@ import os
 
 import sys
 
-import tarfile
-
 import tempfile
 
 from collections import namedtuple
 
-from contextlib import closing
-
 from clint.textui import colored
 
+from psqtraviscontainer import debian
 from psqtraviscontainer import directory
 from psqtraviscontainer import download
 
@@ -135,14 +132,6 @@ class Dpkg(PackageSystem):
                    "--force-yes"] + package_names)
 
 
-def _extract_deb_data(archive, tmp_dir):
-    """Extract archive to tmp_dir."""
-    with closing(archive.getmember("data.tar.gz")) as member:
-        with tarfile.open(fileobj=member,
-                          mode="r|*") as data_tar:
-            data_tar.extractall(path=tmp_dir)
-
-
 class DpkgLocal(PackageSystem):
     """Debian packaging system, installing packages to local directory."""
 
@@ -164,8 +153,6 @@ class DpkgLocal(PackageSystem):
         dpkg manually to install packages into a local
         directory which we control.
         """
-        from debian import arfile  # suppress(import-error)
-
         _run_task(self._executor,
                   """Update repositories""",
                   ["apt-get", "update", "-qq", "-y", "--force-yes"])
@@ -178,7 +165,7 @@ class DpkgLocal(PackageSystem):
                 debs = fnmatch.filter(os.listdir("."), "*.deb")
                 for deb in debs:
                     _report_task("""Extracting {}""".format(deb))
-                    _extract_deb_data(arfile.ArFile(deb), root)
+                    debian.extract_deb_data(deb, root)
 
 
 class Yum(PackageSystem):


### PR DESCRIPTION
Using dpkg is slow and error-prone. We were overriding enough dependency checking anyway that it makes more sense to just unpack the packages.