### PR TITLE
Use APT to install with --local mode

### DIFF
--- a/psqtraviscontainer/container.py
+++ b/psqtraviscontainer/container.py
@@ -150,13 +150,18 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
                 argv,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                env=None,
                 **kwargs):
         """Execute the process and arguments indicated by argv in container."""
         (argv,
          prepend_env,
          overwrite_env) = self._subprocess_popen_arguments(argv, **kwargs)
 
-        with updated_environ(prepend_env, overwrite_env) as env:
+        # Update overwrite_env with any values that the user may
+        # have provided in env
+        overwrite_env.update(env or {})
+
+        with updated_environ(prepend_env, overwrite_env) as environment:
             if not os.path.exists(argv[0]):
                 abs_argv0 = shutil.which(argv[0])
                 if abs_argv0 is None:
@@ -187,7 +192,7 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
             executed_cmd = subprocess.Popen(argv,
                                             stdout=stdout,
                                             stderr=stderr,
-                                            env=env,
+                                            env=environment,
                                             universal_newlines=True)
 
         stdout_data, stderr_data = executed_cmd.communicate()

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -108,6 +108,34 @@ class LocalLinuxContainer(container.AbstractContainer):
                              "i686-linux-gnu",
                              "pkgconfig")
             ]),
+            "LIBRARY_PATH": os.pathsep.join([
+                os.path.join(self._package_root,
+                             "usr",
+                             "lib"),
+                os.path.join(self._package_root,
+                             "usr",
+                             "lib",
+                             "x86_64-linux-gnu"),
+                os.path.join(self._package_root,
+                             "usr",
+                             "lib",
+                             "i686-linux-gnu")
+            ]),
+            "INCLUDE_PATH": os.pathsep.join([
+                os.path.join(self._package_root,
+                             "usr",
+                             "include")
+            ]),
+            "CPATH": os.pathsep.join([
+                os.path.join(self._package_root,
+                             "usr",
+                             "include")
+            ]),
+            "CPPPATH": os.pathsep.join([
+                os.path.join(self._package_root,
+                             "usr",
+                             "include")
+            ]),
             "PATH": os.pathsep.join([
                 os.path.join(self._package_root,
                              "usr",

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -136,8 +136,7 @@ def container_for_directory(container_dir, distro_config):
                                                distro_config)
 
     return LocalLinuxContainer(cont,
-                               os.path.join(path_to_distro_folder,
-                                            "packages"),
+                               path_to_distro_folder,
                                distro_config["release"],
                                distro_config["arch"],
                                distro_config["pkgsys"])
@@ -150,8 +149,7 @@ def create(container_dir, distro_config):
                                                distro_config)
 
     return LocalLinuxContainer(cont,
-                               os.path.join(path_to_distro_folder,
-                                            "packages"),
+                               path_to_distro_folder,
                                distro_config["release"],
                                distro_config["arch"],
                                distro_config["pkgsys"])

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -397,6 +397,10 @@ class Brew(PackageSystem):
         brew_packages = [p for p in package_names if not urlparse(p).scheme]
 
         _run_task(self._executor,
+                  """Updating repositories""",
+                  ["brew", "update"])
+
+        _run_task(self._executor,
                   """Install {0}""".format(str(brew_packages)),
                   ["brew", "install"] + brew_packages)
 

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -155,12 +155,11 @@ class Dpkg(PackageSystem):
         """Install all packages in list package_names."""
         _run_task(self._executor,
                   """Update repositories""",
-                  ["apt-get", "update", "-qq", "-y", "--force-yes"])
+                  ["apt-get", "update", "-y", "--force-yes"])
         _run_task(self._executor,
                   """Install {0}""".format(str(package_names)),
                   ["apt-get",
                    "install",
-                   "-qq",
                    "-y",
                    "--force-yes"] + package_names)
 

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -21,6 +21,8 @@ import tarfile
 
 import tempfile
 
+import textwrap
+
 from collections import namedtuple
 
 from clint.textui import colored
@@ -44,10 +46,15 @@ def _report_task(description):
     sys.stdout.write(str(colored.white("-> {0}\n".format(description))))
 
 
-def _run_task(executor, description, argv):
+def _run_task(executor, description, argv, env=None, detail=None):
     """Run command through executor argv and prints description."""
-    _report_task(description)
-    executor.execute(argv, requires_full_access=True)
+    detail = "[{}]".format(" ".join(argv)) if detail is None else detail
+    _report_task(description + " " + detail)
+    code, stdout, stderr = executor.execute(argv,
+                                            requires_full_access=True,
+                                            env=env)
+    print(textwrap.indent(stdout, "   "))
+    print(textwrap.indent(stderr, "   "))
 
 
 class PackageSystem(six.with_metaclass(abc.ABCMeta, object)):

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -90,15 +90,29 @@ class Dpkg(PackageSystem):
         self._arch = arch
         self._executor = executor
 
-    def add_repositories(self, repos):
-        """Add a repository to the central packaging system."""
+    @staticmethod
+    def format_repositories(repos, release, arch):
+        """Take a list of APT lines and format them.
+
+        There are certain shortcuts that you can use.
+
+        {ubuntu} will be replaced by http://archive.ubuntu.com/ and
+        the architecture.
+
+        {debian} will be replaced by http://ftp.debian.org/.
+
+        {launchpad} will be replaced by "http://ppa.launchpad.net/.
+
+        {release} gets replaced by the release of the distribution, which
+        means you don't need a repository file for every distribution.
+        """
         _ubuntu_urls = [
             (_UBUNTU_MAIN_ARCHS, _UBUNTU_MAIN_ARCHIVE),
             (_UBUNTU_PORT_ARCHS, _UBUNTU_PORT_ARCHIVE)
         ]
 
         def _format_user_line(line, kwargs):
-            """Format a line and turns it into a valid repo line."""
+            """Format a line and turns it into a valid repository line."""
             formatted_line = line.format(**kwargs)
             return "deb {0}".format(formatted_line)
 
@@ -107,21 +121,27 @@ class Dpkg(PackageSystem):
             return value[0] if len(value) else "ERROR"
 
         format_keys = {
-            "ubuntu": [u[1] for u in _ubuntu_urls if self._arch in u[0]],
+            "ubuntu": [u[1] for u in _ubuntu_urls if arch in u[0]],
             "debian": ["http://ftp.debian.org/"],
             "launchpad": ["http://ppa.launchpad.net/"],
-            "release": [self._release]
+            "release": [release]
         }
         format_keys = {
             k: _value_or_error(v) for k, v in format_keys.items()
         }
 
+        return [_format_user_line(l, format_keys) for l in repos]
+
+    def add_repositories(self, repos):
+        """Add a repository to the central packaging system."""
         # We will be creating a bash script each time we need to add
         # a new source line to our sources list and executing that inside
         # the proot. This guarantees that we'll always get the right
         # permissions.
         with tempfile.NamedTemporaryFile() as bash_script:
-            append_lines = [_format_user_line(l, format_keys) for l in repos]
+            append_lines = Dpkg.format_repositories(repos,
+                                                    self._release,
+                                                    self._arch)
             for count, append_line in enumerate(append_lines):
                 path = "/etc/apt/sources.list.d/{0}.list".format(count)
                 append_cmd = "echo \"{0}\" > {1}\n".format(append_line, path)

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -169,7 +169,7 @@ class DpkgLocal(PackageSystem):
     """Debian packaging system, installing packages to local directory."""
 
     def __init__(self, release, arch, executor):
-        """Initialize this DpkgLocal PackageSystem."""
+        """Initialize this PackageSystem."""
         super(DpkgLocal, self).__init__()
         self._release = release
         self._arch = arch

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -506,8 +506,8 @@ _DISTRO_INFO = {
                           files=["bin/xz"]),
     "Windows": _DistroPackage(package="cmake.portable",
                               repo=[],
-                              files=["lib/cmake.portable.3.5.2/"
-                                     "tools/cmake-3.5.2-win32-x86/bin/"
+                              files=["lib/cmake.portable.3.6.1/"
+                                     "tools/cmake-3.6.1-win32-x86/bin/"
                                      "cmake.exe"])
 }
 


### PR DESCRIPTION
Previously we were downloading debs and unpacking them manually. This doesn't take advantage of APT's built in dependency resolver, which is a nice-to-have.

Creates a root and APT config file that can be used to download and install packages directly into a container, without needing to mess about with `proot`.