### PR TITLE
container: Allow output to be printed "live" and captured

### DIFF
--- a/DICTIONARY
+++ b/DICTIONARY
@@ -30,6 +30,7 @@ homebrew
 LANG
 launchpad
 LC_ALL
+LZMA
 OSX
 overridable
 PATHEXT

--- a/psqtraviscontainer/container.py
+++ b/psqtraviscontainer/container.py
@@ -205,7 +205,7 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
             stdout_monitor = output.monitor(executed_cmd.stdout,
                                             modifier=output_modifier,
                                             live=live_output)
-            stderr_monitor = output.monitor(executed_cmd.stdout,
+            stderr_monitor = output.monitor(executed_cmd.stderr,
                                             modifier=output_modifier,
                                             live=False)
 

--- a/psqtraviscontainer/container.py
+++ b/psqtraviscontainer/container.py
@@ -25,6 +25,8 @@ from contextlib import contextmanager
 
 import parseshebang
 
+from psqtraviscontainer import output
+
 import shutilwhich  # suppress(F401,PYC50,unused-import)
 
 import six
@@ -150,6 +152,8 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
                 argv,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                output_modifier=None,
+                live_output=False,
                 env=None,
                 **kwargs):
         """Execute the process and arguments indicated by argv in container."""
@@ -195,7 +199,21 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
                                             env=environment,
                                             universal_newlines=True)
 
-        stdout_data, stderr_data = executed_cmd.communicate()
+            # Monitor stdout and stderr. We allow live output for
+            # stdout, but not for stderr (so that it gets printed
+            # at the end)
+            stdout_monitor = output.monitor(executed_cmd.stdout,
+                                            modifier=output_modifier,
+                                            live=live_output)
+            stderr_monitor = output.monitor(executed_cmd.stdout,
+                                            modifier=output_modifier,
+                                            live=False)
+
+            try:
+                executed_cmd.wait()
+            finally:
+                stdout_data = stdout_monitor().read()
+                stderr_data = stderr_monitor().read()
 
         return (executed_cmd.returncode, stdout_data, stderr_data)
 
@@ -207,7 +225,9 @@ class AbstractContainer(six.with_metaclass(abc.ABCMeta, object)):
                                                             **kwargs)
 
         if returncode != 0:
-            sys.stderr.write(stdout_data)
+            if not kwargs.get("live"):
+                sys.stderr.write(stdout_data)
+
             sys.stderr.write(stderr_data)
             raise RuntimeError("""{0} failed with {1}""".format(" ".join(argv),
                                                                 returncode))

--- a/psqtraviscontainer/distro.py
+++ b/psqtraviscontainer/distro.py
@@ -95,14 +95,15 @@ def lookup(arguments):
 
     # As last resort, look inside the container directory and see if there
     # is something in there that we know about.
-    try:
-        distro_info = read_existing(arguments["containerdir"])
-        matched_distribution = _search_for_matching_distro(distro_info)
+    if arguments.get("containerdir", None):
+        try:
+            distro_info = read_existing(arguments["containerdir"])
+            matched_distribution = _search_for_matching_distro(distro_info)
 
-        if matched_distribution:
-            return matched_distribution
-    except NoDistributionDetailsError:  # suppress(pointless-except)
-        pass
+            if matched_distribution:
+                return matched_distribution
+        except NoDistributionDetailsError:  # suppress(pointless-except)
+            pass
 
     raise RuntimeError("""Couldn't find matching distribution """
                        """({0})""".format(repr(arguments)))

--- a/psqtraviscontainer/distro.py
+++ b/psqtraviscontainer/distro.py
@@ -58,7 +58,7 @@ def read_existing(container_dir):
     try:
         with open(os.path.join(container_dir, ".distroinfo")) as distroinfo_f:
             return json.load(distroinfo_f)
-    except OSError as error:
+    except EnvironmentError as error:
         if error.errno == errno.ENOENT:
             raise NoDistributionDetailsError()
         else:

--- a/psqtraviscontainer/distro.py
+++ b/psqtraviscontainer/distro.py
@@ -5,7 +5,13 @@
 # See /LICENCE.md for Copyright information
 """Various distribution configurations are stored here."""
 
+import errno
+
 import itertools
+
+import json
+
+import os
 
 from collections import namedtuple
 
@@ -41,16 +47,62 @@ def available_distributions():
             yield config
 
 
-def lookup(arguments):
-    """Look up DistroConfig by matching against its name and arguments."""
+class NoDistributionDetailsError(Exception):
+    """An exception that is raised if there is no distribution in a path."""
+
+    pass
+
+
+def read_existing(container_dir):
+    """Attempt to detect an existing distribution in container_dir."""
+    try:
+        with open(os.path.join(container_dir, ".distroinfo")) as distroinfo_f:
+            return json.load(distroinfo_f)
+    except OSError as error:
+        if error.errno == errno.ENOENT:
+            raise NoDistributionDetailsError()
+        else:
+            raise error
+
+
+def write_details(container_dir, selected_distro):
+    """Write details of selected_distro to container_dir."""
+    with open(os.path.join(container_dir, ".distroinfo"), "w") as info_f:
+        keys = ("distro", "installation", "arch", "release")
+        info_f.write(json.dumps({
+            k: v for k, v in selected_distro.items()
+            if k in keys
+        }))
+
+
+def _search_for_matching_distro(distro_info):
+    """Check all known distributions for one matching distro_info."""
     matched_distribution = None
 
     for distribution in _distribution_information():
         matched_distribution = distribution.match_func(distribution,
-                                                       arguments)
+                                                       distro_info)
         if matched_distribution:
             matched_distribution["info"] = distribution
             return matched_distribution
+
+
+def lookup(arguments):
+    """Look up DistroConfig by matching against its name and arguments."""
+    matched_distribution = _search_for_matching_distro(arguments)
+    if matched_distribution:
+        return matched_distribution
+
+    # As last resort, look inside the container directory and see if there
+    # is something in there that we know about.
+    try:
+        distro_info = read_existing(arguments["containerdir"])
+        matched_distribution = _search_for_matching_distro(distro_info)
+
+        if matched_distribution:
+            return matched_distribution
+    except NoDistributionDetailsError:  # suppress(pointless-except)
+        pass
 
     raise RuntimeError("""Couldn't find matching distribution """
                        """({0})""".format(repr(arguments)))

--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -503,7 +503,7 @@ def _fetch_distribution(container_root,  # pylint:disable=R0913
 
         pkgs = set(cont.execute(["dpkg-query",
                                  "-Wf",
-                                 "${Package} "])[1].split(" "))
+                                 "${Package}\n"])[1].split("\n"))
         release = details["release"]
         remove = [l for l in list(pkgs ^ required_packages[release]) if len(l)]
 

--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -631,6 +631,9 @@ def match(info, arguments):
     if arguments.get("local", None):
         return None
 
+    if arguments.get("installation", None) == "local":
+        return None
+
     distro_release = info.kwargs["release"]
 
     # pychecker thinks that a list comprehension as a return value is

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -208,7 +208,8 @@ def match(info, arguments):
     if arguments.get("distro", None) != info.kwargs["distro"]:
         return None
 
-    if not arguments.get("local", None):
+    if not (arguments.get("local", None) or
+            arguments.get("installation", None) == "local"):
         return None
 
     distro_release = info.kwargs["release"]

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -1,13 +1,11 @@
 # /psqtraviscontainer/linux_local_container.py
 #
-# Specialization for linux containers, using a variant
-# of linux_container. This variant uses proot to set
-# up the container, but installs packages into a
-# separate directory and makes them available using
-# paths.
+# Specialization for linux containers. This version bootstraps
+# package manager locally, without root access, and uses
+# environment variables to control binary access.
 #
 # See /LICENCE.md for Copyright information
-"""Specialization for linux containers, using proot."""
+"""Specialization for linux containers, using environment variables."""
 
 from __future__ import unicode_literals
 

--- a/psqtraviscontainer/osx_container.py
+++ b/psqtraviscontainer/osx_container.py
@@ -105,7 +105,8 @@ def _fetch_homebrew(container_dir, distro_config):
         return container_for_directory(container_dir, distro_config)
     except OSError:
         with directory.Navigation(tempdir.TempDir().name):
-            with TemporarilyDownloadedFile(_HOMEBREW_URL) as archive_file:
+            with TemporarilyDownloadedFile(_HOMEBREW_URL,
+                                           filename="brew") as archive_file:
                 with directory.Navigation(tempdir.TempDir().name) as extract:
                     _extract_archive(archive_file, extract)
                     first = os.path.join(extract,

--- a/psqtraviscontainer/output.py
+++ b/psqtraviscontainer/output.py
@@ -1,0 +1,47 @@
+# /psqtraviscontainer/output.py
+#
+# Helper classes to monitor and capture output as it runs.
+#
+# See /LICENCE.md for Copyright information
+"""Helper classes to monitor and capture output as it runs."""
+
+import sys
+
+import threading
+
+
+def monitor(stream,
+            modifier=None,
+            live=False,
+            output=sys.stdout):
+    """Monitor and print lines from stream until end of file is reached.
+
+    Each line is piped through :modifier:.
+    """
+    from six import StringIO
+    captured = StringIO()
+    modifier = modifier or (lambda l: l)
+
+    def read_thread():
+        """Read each line from the stream and print it."""
+        for line in stream:
+            line = modifier(line)
+            captured.write(line)
+            if live:
+                output.write(line)
+
+    def joiner_for_output(thread):
+        """Closure to join the thread and do something with its output."""
+        thread.start()
+
+        def join():
+            """Join the thread and then return its output."""
+            thread.join()
+            return captured
+
+        return join
+
+    # Note that while it is necessary to call joiner_for_output if you want
+    # resources to be cleaned up, it is not necessary if you don't care
+    # about cleanup and just want the program to keep running.
+    return joiner_for_output(threading.Thread(target=read_thread))

--- a/psqtraviscontainer/output.py
+++ b/psqtraviscontainer/output.py
@@ -37,6 +37,7 @@ def monitor(stream,
         def join():
             """Join the thread and then return its output."""
             thread.join()
+            captured.seek(0)
             return captured
 
         return join

--- a/psqtraviscontainer/output.py
+++ b/psqtraviscontainer/output.py
@@ -24,6 +24,10 @@ def monitor(stream,
 
     def read_thread():
         """Read each line from the stream and print it."""
+        # No stream, not much we can really do here.
+        if not stream:
+            return
+
         for line in stream:
             line = modifier(line)
             captured.write(line)

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -265,7 +265,7 @@ class DpkgLocal(PackageSystem):
         try:
             with open(sources_list) as sources:
                 known_repos = [s for s in sources.read().split("\n") if len(s)]
-        except OSError as error:
+        except EnvironmentError as error:
             if error.errno != errno.ENOENT:
                 raise error
 

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -49,13 +49,20 @@ def _report_task(description):
 
 def _run_task(executor, description, argv, env=None, detail=None):
     """Run command through executor argv and prints description."""
+    def wrapper(line):
+        """Output wrapper for line."""
+        return textwrap.indent(line, "   ")
+
     detail = "[{}]".format(" ".join(argv)) if detail is None else detail
     _report_task(description + " " + detail)
-    code, stdout, stderr = executor.execute(argv,
-                                            requires_full_access=True,
-                                            env=env)
-    print(textwrap.indent(stdout, "   "))
-    print(textwrap.indent(stderr, "   "))
+    (code,
+     stdout_data,
+     stderr_data) = executor.execute(argv,
+                                     output_modifier=wrapper,
+                                     live_output=True,
+                                     requires_full_access=True,
+                                     env=env)
+    sys.stderr.write(stderr_data)
 
 
 def _format_package_list(packages):

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -248,6 +248,7 @@ class DpkgLocal(PackageSystem):
             "debug {",
             "    nolocking true;"
             "};"
+            "Acquire::Queue-Mode \"host\";",
             "Dir \"" + root + "\";",
             "Dir::Cache \"" + root + "/var/cache/apt\";",
             "Dir::State \"" + root + "/var/lib/apt\";"

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -336,13 +336,11 @@ class DpkgLocal(PackageSystem):
         # Go back into our archives directory and unpack all our packages
         with directory.Navigation(archives):
             package_files = fnmatch.filter(os.listdir("."), "*.deb")
-            _run_task(self._executor,
-                      """Unpacking packages""",
-                      ["dpkg",
-                       "-i",
-                       "--root=" + root,
-                       "--force-all"] + package_files,
-                      detail="")
+            for pkg in package_files:
+                _run_task(self._executor,
+                          """Unpacking """,
+                          ["dpkg", "-x", pkg, root],
+                          detail=os.path.splitext(os.path.basename(pkg))[0])
 
 
 class Yum(PackageSystem):

--- a/psqtraviscontainer/use.py
+++ b/psqtraviscontainer/use.py
@@ -18,7 +18,7 @@ def _parse_arguments(arguments=None):
     parser = common_options.get_parser("Use")
     parser.add_argument("--show-output",
                         action="store_true",
-                        help="""Don't buffer output and show it immediately.""")
+                        help="""Don't buffer output - show it immediately.""")
     return parser.parse_args(arguments)
 
 

--- a/psqtraviscontainer/use.py
+++ b/psqtraviscontainer/use.py
@@ -18,7 +18,7 @@ def _parse_arguments(arguments=None):
     parser = common_options.get_parser("Use")
     parser.add_argument("--show-output",
                         action="store_true",
-                        help="""Show output of commands once they've run.""")
+                        help="""Don't buffer output and show it immediately.""")
     return parser.parse_args(arguments)
 
 
@@ -48,7 +48,9 @@ def main(arguments=None):
                 "stdout": None
             }
         else:
-            execute_kwargs = dict()
+            execute_kwargs = {
+                "live_output": True
+            }
 
         result = container.execute(command, **execute_kwargs)[0]
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if platform.system() != "Windows":
     ])
 
 setup(name="polysquare-travis-container",
-      version="0.0.36",
+      version="0.0.37",
       description="""Polysquare Travis-CI Container Root""",
       long_description_markdown_filename="README.md",
       author="Sam Spilsbury",

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -350,9 +350,9 @@ class TestExecInContainer(TestCase):
     def test_exec_fail_no_distro(self):  # suppress(no-self-use)
         """Check that use.main() fails where there is no distro."""
         with run_create_default_container() as container_dir:
-            with ExpectedException(RuntimeError):
-                cmd = PLATFORM_PROGRAM_MAPPINGS[platform.system()]["0"]
-                run_use_container_on_dir(container_dir, cmd=cmd)
+            cmd = PLATFORM_PROGRAM_MAPPINGS[platform.system()]["0"]
+            self.assertEqual(run_use_container_on_dir(container_dir,
+                                                      cmd=cmd), 0)
 
     def test_exec_return_zero(self):
         """Check that use.main() returns true exit code of subprocess."""

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -349,6 +349,15 @@ class TestExecInContainer(TestCase):
 
     def test_exec_fail_no_distro(self):  # suppress(no-self-use)
         """Check that use.main() fails where there is no distro."""
+        with SafeTempDir() as container_dir:
+            with ExpectedException(RuntimeError):
+                cmd = PLATFORM_PROGRAM_MAPPINGS[platform.system()]["0"]
+                run_use_container_on_dir(container_dir, cmd=cmd)
+
+    def test_exec_success_where_distro(self):  # suppress(no-self-use)
+        """Check that use.main() succeeds where there is a distro."""
+        # This will test that we can use "use.main()" without needing
+        # to specify a distro configuration
         with run_create_default_container() as container_dir:
             cmd = PLATFORM_PROGRAM_MAPPINGS[platform.system()]["0"]
             self.assertEqual(run_use_container_on_dir(container_dir,


### PR DESCRIPTION
This allows the user to see what is going on and mitigates
issues with travis-ci timing out when commands take too
long.

Also added code that simplified the use of
psq-travis-container-exec. There is now no longer
a need to specify a distro and release if a container
already exists and it has a .distroinfo file in it.