### PR TITLE
linux: Completely separate local containers from proot containers

### DIFF
--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -382,9 +382,9 @@ def _clear_postrm_scripts_in_root(container_root):
         os.remove(os.path.join(scripts_dir, script))
 
 
-def _fetch_distribution(container_root,  # pylint:disable=R0913
-                        proot_distro,
-                        details):
+def fetch_distribution(container_root,  # pylint:disable=R0913
+                       proot_distro,
+                       details):
     """Lazy-initialize distribution and return it."""
     path_to_distro_folder = get_dir_for_distro(container_root,
                                                details)

--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -541,6 +541,8 @@ def fetch_distribution(container_root,  # pylint:disable=R0913
         release = details["release"]
         remove = [l for l in list(pkgs ^ required_packages[release]) if len(l)]
 
+        _clear_postrm_scripts_in_root(root)
+
         if len(remove):
             cont.execute_success(["dpkg",
                                   "--root={}".format(root),

--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -541,7 +541,8 @@ def fetch_distribution(container_root,  # pylint:disable=R0913
         release = details["release"]
         remove = [l for l in list(pkgs ^ required_packages[release]) if len(l)]
 
-        _clear_postrm_scripts_in_root(root)
+        if root != "/":
+            _clear_postrm_scripts_in_root(root)
 
         if len(remove):
             cont.execute_success(["dpkg",

--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -694,6 +694,12 @@ def enumerate_all(info):
     if platform.system() != "Linux":
         return
 
+    # proot based distributions are completely broken on
+    # Travis-CI (just exits with signal 11 immediately after
+    # execution) so don't even both running them here.
+    if os.environ.get("CI"):
+        return
+
     for arch in _valid_archs(info.kwargs["arch"]):  # suppress(PYC90)
         yield _info_with_arch_to_config(info, arch)
 

--- a/psqtraviscontainer/linux_container.py
+++ b/psqtraviscontainer/linux_container.py
@@ -380,6 +380,8 @@ def _clear_postrm_scripts_in_root(container_root):
         os.remove(os.path.join(scripts_dir, script))
     for script in fnmatch.filter(os.listdir(scripts_dir), "*.prerm"):
         os.remove(os.path.join(scripts_dir, script))
+    for script in fnmatch.filter(os.listdir(scripts_dir), "*.postinst"):
+        os.remove(os.path.join(scripts_dir, script))
 
 
 def fetch_distribution(container_root,  # pylint:disable=R0913

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -69,7 +69,6 @@ class LocalLinuxContainer(container.AbstractContainer):
         proot command to enter this container will be prepended to the
         argv provided.
         """
-
         popen_args = self.__class__.PopenArguments
         prepend_env = {
             "LD_LIBRARY_PATH": os.pathsep.join([

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -44,14 +44,12 @@ class LocalLinuxContainer(container.AbstractContainer):
     """
 
     def __init__(self,  # suppress(too-many-arguments)
-                 linux_cont,
                  package_root,
                  release,
                  arch,
                  pkg_sys_constructor):
         """Initialize this LocalLinuxContainer, storing its distro config."""
         super(LocalLinuxContainer, self).__init__()
-        self._linux_cont = linux_cont
         self._arch = arch
         self._package_root = package_root
         self._pkgsys = pkg_sys_constructor(release, arch, self)
@@ -70,14 +68,7 @@ class LocalLinuxContainer(container.AbstractContainer):
         This returned tuple will have no environment variables set, but the
         proot command to enter this container will be prepended to the
         argv provided.
-
-        Set the requires_full_access keyword to run this command through the
-        proot wrapper.
         """
-        if kwargs.get("requires_full_access", None):
-            # suppress(protected-access)
-            return self._linux_cont._subprocess_popen_arguments(argv,
-                                                                **kwargs)
 
         popen_args = self.__class__.PopenArguments
         prepend_env = {
@@ -182,13 +173,10 @@ def container_for_directory(container_dir, distro_config):
     Also take into account arguments in result to look up the the actual
     directory for this distro.
     """
-    cont = linux_container.container_for_directory(container_dir,
-                                                   distro_config)
     path_to_distro_folder = get_dir_for_distro(container_dir,
                                                distro_config)
 
-    return LocalLinuxContainer(cont,
-                               path_to_distro_folder,
+    return LocalLinuxContainer(path_to_distro_folder,
                                distro_config["release"],
                                distro_config["arch"],
                                distro_config["pkgsys"])
@@ -196,14 +184,13 @@ def container_for_directory(container_dir, distro_config):
 
 def create(container_dir, distro_config):
     """Create a container using proot."""
-    cont, minimize_actions = linux_container.fetch_distribution(container_dir,
-                                                                None,
-                                                                distro_config)
+    _, minimize_actions = linux_container.fetch_distribution(container_dir,
+                                                             None,
+                                                             distro_config)
     path_to_distro_folder = get_dir_for_distro(container_dir,
                                                distro_config)
 
-    local_container = LocalLinuxContainer(cont,
-                                          path_to_distro_folder,
+    local_container = LocalLinuxContainer(path_to_distro_folder,
                                           distro_config["release"],
                                           distro_config["arch"],
                                           distro_config["pkgsys"])

--- a/psqtraviscontainer/linux_local_container.py
+++ b/psqtraviscontainer/linux_local_container.py
@@ -296,7 +296,7 @@ DISTRIBUTIONS = [  # suppress(unused-variable)
                         "releases/12.04.3/release/"
                         "ubuntu-core-12.04.3-core-{arch}.tar.gz"),
                    arch=["i386", "amd64", "armhf"],
-                   archfetch=architecture.Alias.debian,),
+                   archfetch=architecture.Alias.debian),
     LinuxLocalInfo("Ubuntu",
                    release="trusty",
                    url=("http://old-releases.ubuntu.com/releases/ubuntu-core/"

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -320,7 +320,7 @@ class DpkgLocal(PackageSystem):
 
         root = self._executor.root_filesystem_directory()
         environment = {
-            "APT_CONFIG": os.path.join(root, "etc", "apt.conf")
+            "APT_CONFIG": os.path.join(root, "etc", "apt", "apt.conf")
         }
         _run_task(self._executor,
                   """Update repositories""",

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -17,6 +17,8 @@ import platform
 
 import shutil
 
+import stat
+
 import subprocess
 
 import sys
@@ -266,6 +268,18 @@ class DpkgLocal(PackageSystem):
         apt_config_path = os.path.join(root, "etc", "apt", "apt.conf")
         with open(apt_config_path, "w") as config_file:
             config_file.write(config_file_contents)
+
+        dpkg_script_contents = "\n".join([
+            "#!/bin/bash",
+            root + "/usr/bin/dpkg --root='" + root + "' \\",
+            "--admindir=" + root + "/var/lib/dpkg \\",
+            "--log=" + root + "/var/log/dkpkg.log \\",
+            "--force-not-root --force-bad-path $@"
+        ])
+        dpkg_bin_path = os.path.join(root, "usr", "bin", "dpkg.w")
+        with open(dpkg_bin_path, "w") as dpkg_bin:
+            dpkg_bin.write(dpkg_script_contents)
+        os.chmod(dpkg_bin_path, os.stat(dpkg_bin_path).st_mode | stat.S_IXUSR)
 
     def add_repositories(self, repos):
         """Add repository to the central packaging system."""

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -248,8 +248,8 @@ class DpkgLocal(PackageSystem):
             "    };",
             "};",
             "debug {",
-            "    nolocking true;"
-            "};"
+            "    nolocking true;",
+            "};",
             "Acquire::Queue-Mode \"host\";",
             "Dir \"" + root + "\";",
             "Dir::Cache \"" + root + "/var/cache/apt\";",

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -62,7 +62,6 @@ def _run_task(executor, description, argv, env=None, detail=None):
      stderr_data) = executor.execute(argv,
                                      output_modifier=wrapper,
                                      live_output=True,
-                                     requires_full_access=True,
                                      env=env)
     sys.stderr.write(stderr_data)
 

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -263,7 +263,8 @@ class DpkgLocal(PackageSystem):
             "Dir::Etc \"" + root + "/etc/apt\";",
             "Dir::Log \"" + root + "/var/log/apt\";"
         ])
-        with open(os.path.join(root, "etc", "apt.conf"), "w") as config_file:
+        apt_config_path = os.path.join(root, "etc", "apt", "apt.conf")
+        with open(apt_config_path, "w") as config_file:
             config_file.write(config_file_contents)
 
     def add_repositories(self, repos):

--- a/psqtraviscontainer/package_system.py
+++ b/psqtraviscontainer/package_system.py
@@ -253,7 +253,15 @@ class DpkgLocal(PackageSystem):
             "Acquire::Queue-Mode \"host\";",
             "Dir \"" + root + "\";",
             "Dir::Cache \"" + root + "/var/cache/apt\";",
-            "Dir::State \"" + root + "/var/lib/apt\";"
+            "Dir::State \"" + root + "/var/lib/apt\";",
+            "Dir::State::status \"" + root + "/var/lib/dpkg/status\";",
+            "Dir::Bin::Solvers \"" + root + "/usr/lib/apt/solvers\";",
+            "Dir::Bin::Planners \"" + root + "/usr/lib/apt/planners\";",
+            "Dir::Bin::Solvers \"" + root + "/usr/lib/apt/solvers\";",
+            "Dir::Bin::Methods \"" + root + "/usr/lib/apt/methods\";",
+            "Dir::Bin::Dpkg \"" + root + "/usr/bin/dpkg.w\";",
+            "Dir::Etc \"" + root + "/etc/apt\";",
+            "Dir::Log \"" + root + "/var/log/apt\";"
         ])
         with open(os.path.join(root, "etc", "apt.conf"), "w") as config_file:
             config_file.write(config_file_contents)

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -123,8 +123,6 @@ def run_create_container(**kwargs):
 
 def default_create_container_arguments():
     """Get set of arguments which would create first known distribution."""
-    import pprint
-    raise RuntimeError(pprint.pformat(list(available_distributions())))
     distro_config = list(available_distributions())[0]
     arguments = ("distro", "release")
     config = {k: v for k, v in distro_config.items() if k in arguments}

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -58,8 +58,10 @@ def _convert_to_switch_args(kwargs):
             return str(value)
 
     for key, value in kwargs.items():
-        arguments.append("--{0}".format(key))
-        arguments.append(_get_representation(value))
+        if not isinstance(value, bool) or value:
+            arguments.append("--{0}".format(key))
+        if not isinstance(value, bool):
+            arguments.append(_get_representation(value))
 
     return arguments
 

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -167,6 +167,13 @@ def test_case_requiring_platform(system):
 class TestCreateProot(test_case_requiring_platform("Linux")):
     """A test case for proot creation basics."""
 
+    def setUp(self):
+        """Set up the test case and check that we can run it."""
+        if os.environ.get("TRAVIS", False):
+            self.skipTest("""Cannot run proot on travis-ci""")
+
+        super(TestCreateProot, self).setUp()
+
     def test_create_proot_distro(self):
         """Check that we create a proot distro."""
         with run_create_default_container() as container:
@@ -282,6 +289,9 @@ class TestProotDistribution(ContainerInspectionTestCase):
         """Set up TestProotDistribution."""
         if platform.system() != "Linux":
             self.skipTest("""proot is only available on linux""")
+
+        if os.environ.get("TRAVIS", False):
+            self.skipTest("""Cannot run proot on travis-ci""")
 
         super(TestProotDistribution, self).setUp()
 

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -261,6 +261,12 @@ def make_container_inspection_test_case(**create_container_kwargs):
         @classmethod
         def setUpClass(cls):  # suppress(N802)
             """Set up container for all tests in this test case."""
+            # Detect if we're about to create a non-local container on an
+            # environment that doesn't support it
+            if (create_container_kwargs.get("local", None) is False and
+                    os.environ.get("TRAVIS", None)):
+                return
+
             with temporary_environment(_FORCE_DOWNLOAD_QEMU="True"):
                 apply_kwargs = create_container_kwargs
                 config = default_create_container_arguments(**apply_kwargs)

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -545,8 +545,8 @@ _DISTRO_INFO = {
                           files=["bin/xz"]),
     "Windows": _DistroPackage(package="cmake.portable",
                               repo=[],
-                              files=["lib/cmake.portable.3.6.1/"
-                                     "tools/cmake-3.6.1-win32-x86/bin/"
+                              files=["lib/cmake.portable.3.7.0/"
+                                     "tools/cmake-3.7.0-win32-x86/bin/"
                                      "cmake.exe"])
 }
 

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -471,7 +471,7 @@ def _create_distro_test(test_name,  # pylint:disable=R0913
         def setUpClass(cls):  # suppress(N802)
             """Create a container for all uses of this TemplateDistroTest."""
             with InstallationConfig(packages, repos) as command_config:
-                keys = ("distro", "release", "local")
+                keys = ("distro", "release")
                 kwargs.update({k: v for k, v in config.items() if k in keys})
 
                 cls.create_container(repos=command_config.repos_path,
@@ -579,6 +579,10 @@ def get_distribution_tests():
         except KeyError:  # suppress(pointless-except)
             pass
 
+        # Set the --local switch if the installation type is local. This is
+        # because we pass the keyword arguments to the main function of
+        # psq-travis-container-create
+        kwargs["local"] = (config.get("installation", None) == "local")
         tests[name] = _create_distro_test(name,
                                           config,
                                           repositories_to_add,

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -123,17 +123,21 @@ def run_create_container(**kwargs):
     return temp_dir
 
 
-def default_create_container_arguments():
+def default_create_container_arguments(local=True):
     """Get set of arguments which would create first known distribution."""
     distro_config = list(available_distributions())[0]
     arguments = ("distro", "release")
     config = {k: v for k, v in distro_config.items() if k in arguments}
+
+    # We must force local to true here so that it gets passed to
+    # the underlying container
+    config["local"] = local
     return config
 
 
-def run_create_default_container():
+def run_create_default_container(local=True):
     """Run main() and return container for first known distribution."""
-    return run_create_container(**(default_create_container_arguments()))
+    return run_create_container(**(default_create_container_arguments(local)))
 
 
 def run_use_container_on_dir(directory, **kwargs):

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -471,7 +471,7 @@ def _create_distro_test(test_name,  # pylint:disable=R0913
         def setUpClass(cls):  # suppress(N802)
             """Create a container for all uses of this TemplateDistroTest."""
             with InstallationConfig(packages, repos) as command_config:
-                keys = ("distro", "release")
+                keys = ("distro", "release", "local")
                 kwargs.update({k: v for k, v in config.items() if k in keys})
 
                 cls.create_container(repos=command_config.repos_path,

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -123,6 +123,8 @@ def run_create_container(**kwargs):
 
 def default_create_container_arguments():
     """Get set of arguments which would create first known distribution."""
+    import pprint
+    raise RuntimeError(pprint.pformat(list(available_distributions())))
     distro_config = list(available_distributions())[0]
     arguments = ("distro", "release")
     config = {k: v for k, v in distro_config.items() if k in arguments}

--- a/test/test_acceptance.py
+++ b/test/test_acceptance.py
@@ -176,7 +176,7 @@ class TestCreateProot(test_case_requiring_platform("Linux")):
 
     def test_create_proot_distro(self):
         """Check that we create a proot distro."""
-        with run_create_default_container() as container:
+        with run_create_default_container(local=False) as container:
             self.assertThat(have_proot_distribution(container),
                             FileExists())
 
@@ -187,12 +187,12 @@ class TestCreateProot(test_case_requiring_platform("Linux")):
         make sure that across two runs they are actual. If they were,
         then no re-downloading took place.
         """
-        with run_create_default_container() as container:
+        with run_create_default_container(local=False) as container:
             path_to_proot_stamp = have_proot_distribution(container)
 
             first_timestamp = os.stat(path_to_proot_stamp).st_mtime
 
-            config = default_create_container_arguments()
+            config = default_create_container_arguments(local=False)
             run_create_container_on_dir(container, **config)
 
             second_timestamp = os.stat(path_to_proot_stamp).st_mtime
@@ -225,47 +225,55 @@ def cached_downloads():
         sys.stderr = original_stderr
 
 
-class ContainerInspectionTestCase(TestCase):
-    """TestCase where container persists until all tests have completed.
+def make_container_inspection_test_case(**create_container_kwargs):
+    """Make a TestCase which persists a container until test are complete.
 
-    No modifications should be made to the container during any
-    individual test. The order of tests should not be relied upon.
+    create_container_kwargs is stored and applied to creating the container -
+    this allows us to switch between proot-based and non-proot containers.
     """
+    class ContainerInspectionTestCase(TestCase):
+        """TestCase where container persists until all tests have completed.
 
-    container_temp_dir = None
+        No modifications should be made to the container during any
+        individual test. The order of tests should not be relied upon.
+        """
 
-    def __init__(self, *args, **kwargs):
-        """Initialize class."""
-        cls = ContainerInspectionTestCase
-        super(cls, self).__init__(*args, **kwargs)
-        self.container_dir = None
+        container_temp_dir = None
 
-    def setUp(self):  # suppress(N802)
-        """Set up container dir."""
-        super(ContainerInspectionTestCase, self).setUp()
-        self.container_dir = self.__class__.container_temp_dir.name
+        def __init__(self, *args, **kwargs):
+            """Initialize class."""
+            cls = ContainerInspectionTestCase
+            super(cls, self).__init__(*args, **kwargs)
+            self.container_dir = None
 
-    @classmethod
-    def create_container(cls, **kwargs):
-        """Overridable method to create a container for this test case."""
-        cls.container_temp_dir = run_create_container(**kwargs)
+        def setUp(self):  # suppress(N802)
+            """Set up container dir."""
+            super(ContainerInspectionTestCase, self).setUp()
+            self.container_dir = self.__class__.container_temp_dir.name
 
-    # Suppress flake8 complaints about uppercase characters in function names,
-    # these functions are overloaded
-    @classmethod
-    def setUpClass(cls):  # suppress(N802)
-        """Set up container for all tests in this test case."""
-        with temporary_environment(_FORCE_DOWNLOAD_QEMU="True"):
-            config = default_create_container_arguments()
-            cls.create_container(**config)
+        @classmethod
+        def create_container(cls, **kwargs):
+            """Overridable method to create a container for this test case."""
+            cls.container_temp_dir = run_create_container(**kwargs)
 
-    @classmethod
-    def tearDownClass(cls):  # suppress(N802)
-        """Dissolve container for all tests in this test case."""
-        if cls.container_temp_dir:
-            cls.container_temp_dir.dissolve()
-            cls.container_temp_dir = None
+        # Suppress flake8 complaints about uppercase characters in function
+        # names, these functions are overloaded
+        @classmethod
+        def setUpClass(cls):  # suppress(N802)
+            """Set up container for all tests in this test case."""
+            with temporary_environment(_FORCE_DOWNLOAD_QEMU="True"):
+                apply_kwargs = create_container_kwargs
+                config = default_create_container_arguments(**apply_kwargs)
+                cls.create_container(**config)
 
+        @classmethod
+        def tearDownClass(cls):  # suppress(N802)
+            """Dissolve container for all tests in this test case."""
+            if cls.container_temp_dir:
+                cls.container_temp_dir.dissolve()
+                cls.container_temp_dir = None
+
+    return ContainerInspectionTestCase
 
 QEMU_ARCHITECTURES = [
     "arm",
@@ -282,7 +290,7 @@ def _format_arch(func, num, params):
     return func.__doc__.format(arch=params[0][0])
 
 
-class TestProotDistribution(ContainerInspectionTestCase):
+class TestProotDistribution(make_container_inspection_test_case(local=False)):
     """Tests to inspect a proot distribution itself."""
 
     def setUp(self):   # suppress(N802)
@@ -440,7 +448,7 @@ def _create_distro_test(test_name,  # pylint:disable=R0913
                         test_files,
                         **kwargs):
     """Create a TemplateDistroTest class."""
-    class TemplateDistroTest(ContainerInspectionTestCase):
+    class TemplateDistroTest(make_container_inspection_test_case()):
         """Template for checking a distro proot."""
 
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Make it possible to use `linux_local_conatiner` without `proot`. `proot` is broken on travis-ci so we can't use it there at all. This necessitated changes and refactoring in a few places, but we tightened up our configuration of `apt.conf` on `DpkgLocal` so that most accesses to dpkg-related state are made out of the 'containerised' environment instead of the root directory.

This at least makes it possible to install and run packages on both Ubuntu Trusty and Precise.